### PR TITLE
update pnpm-lock.yaml to reference GitHub repositories for `genericsuite` and `genericsuite-ai`, and update dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Removed
 
 
-## [1.3.0](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/1.3.0) (2025-09-03)
+## [1.3.0] (2025-09-03)
 
 ### Added
 - Add new MCP server for ExampleApp with food and nutrition management tools [GS-189]. 
 - Add the `make link_gs_libs` documentation to the GS BE Scripts.
 - Add unlinking common assets and prompting user confirmation before cleaning directories in the `make exampleapp-clean` command.
 - Add "clean" command in Makefile for asset management.
+- Add: new `update-pnpm` command in ExampleApp Makefile for streamlined installation.
 
 ### Changed
 - Update .gitignore to include IDE configurations and remove unused utility files.
@@ -37,14 +38,14 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Fix "mkdocs_install.sh" to update mkdocs dependencies to the latest version and rebuild requirements.txt file appropiately.
 
 
-## [1.2.0](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/1.2.0) (2025-07-13)
+## [1.2.0] (2025-07-13)
 ---
 
 ### Added
 - Add the Release page with the latest GenericSuite releases since 2024-10-07 [GS-222].
 
 
-## [1.1.0](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/1.1.0) (2025-07-12)
+## [1.1.0] (2025-07-12)
 
 ### Added
 - Add the source code link in the Basecamp README.md file [GS-137].
@@ -62,7 +63,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Fix the "Failed to send compressed multipart ingest: langsmith.utils.LangSmithError" error running queries to the AI Assistant by commenting the "LANGCHAIN_API_KEY" and "LANGCHAIN_PROJECT" environment variables in the "exampleapp/apps/**/.env.example" files.
 
 
-## [1.0.0](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/1.0.0) (2025-07-08)
+## [1.0.0] (2025-07-08)
 
 ### Added
 - Add Code example monorepo [GS-137].
@@ -96,7 +97,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Fix: chalice config template file in documentation.
 
 
-## [0.0.13](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/0.0.13) (2025-02-18)
+## [0.0.13] (2025-02-18)
 
 ### Added
 - Generic CRUD Editor Configuration guide [GS-137].
@@ -123,7 +124,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 - Change "grok-beta" changed to "grok-2" as default model for xAI [GS-157].
 
 
-## [0.0.12](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/0.0.12) (2024-10-07)
+## [0.0.12] (2024-10-07)
 
 ### Added
 - Make DynamoDb tables with prefix work with the GS DB Abstraction [GS-102].
@@ -157,7 +158,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Get rid of eval() in the GS FrontEnd [GS-127].
 
 
-## [0.0.11](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/0.0.11) (2024-07-27)
+## [0.0.11] (2024-07-27)
 
 ### Added
 - Add "mkdocs-print-site-plugin" to create the "site/print_page/index.html" file and be able to generate a .pdf documentation.
@@ -175,7 +176,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Add: GET_SECRETS_ENVVARS and GET_SECRETS_CRITICAL envvars to the GS BE Core documentation to fine-grained disabling of cloud secrets manager for critical secrets and plain envvars [GS-41].
 
 
-## [0.0.10](https://github.com/tomkat-cr/genericsuite-basecamp/releases/tag/0.0.10) (2024-06-06)
+## [0.0.10] (2024-06-06)
 
 ### Added
 - Add REACT_APP_USE_AXIOS env. var. to GenericSuite FE AI [GS-95].
@@ -193,7 +194,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Publish error handling to cath mkdocs not installed [GS-85].
 
 
-## [0.0.8] - 2024-05-20
+## [0.0.8] (2024-05-20)
 
 ### Added
 - Add: GS FE special install from a git repo.
@@ -202,7 +203,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Fix: automatic FTP transfer.
 
 
-## [0.0.7] - 2024-05-09
+## [0.0.7] (2024-05-09)
 
 ### Added
 - Add STORAGE_URL_SEED env. vars. [GS-72].
@@ -213,7 +214,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Change special instructions to remove the fronend install from git/local directory (until find a way to make it work).
 
 
-## [0.0.6] - 2024-05-07
+## [0.0.6] (2024-05-07)
 
 ### Added
 - Add special install instructions.
@@ -227,7 +228,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - History and repositories pages revised.
 
 
-## [0.0.5] - 2024-05-05
+## [0.0.5] (2024-05-05)
 
 ### Added
 - Create a documentation mirror in readthedocs.org [GS-75].
@@ -244,7 +245,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Fix homepage section's image paths.
 
 
-## [0.0.4] - 2024-04-28
+## [0.0.4] (2024-04-28)
 
 ### Changed
 - Change: document the API Keys URLs for each configuration.
@@ -253,13 +254,13 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Add "mkdocs_run.sh" to fix the error running the "mkdocs serve" the first time.
 
 
-## [0.0.3] - 2024-04-18
+## [0.0.3] (2024-04-18)
 
 ### Added
 - More details on framework installation for GS BE Core, and instructions to link the Domains to frontend and backend Apps.
 
 
-## [0.0.2] - 2024-04-18
+## [0.0.2] (2024-04-19)
 
 ### Added
 - Add: Makefile to shortcut mkdocs "install", "serve", build" and "transfer" commands.
@@ -274,7 +275,7 @@ HUGGINGFACE_ENDPOINT_URL replaced by HUGGINGFACE_DEFAULT_CHAT_MODEL [GS-59].
 - Fix: Configuration Guide index at the right side.
 
 
-## [0.0.1] - 2024-04-16
+## [0.0.1] (2024-04-16)
 
 ### Added
 - Initial commits [FA-257] [GS-19].

--- a/docs/Sample-Code/exampleapp/Makefile
+++ b/docs/Sample-Code/exampleapp/Makefile
@@ -12,6 +12,8 @@ install:
 update:
 	pnpm update
 
+update-pnpm: install
+
 build:
 	pnpx turbo build --force
 

--- a/docs/Sample-Code/exampleapp/pnpm-lock.yaml
+++ b/docs/Sample-Code/exampleapp/pnpm-lock.yaml
@@ -45,11 +45,11 @@ importers:
   apps/ui:
     dependencies:
       genericsuite:
-        specifier: ^1.0.25
-        version: 1.0.25(axios@1.10.0)(buffer@5.7.1)(constants-browserify@1.0.0)(crypto-browserify@3.12.1)(downshift@8.5.0(react@19.1.0))(express@4.21.2)(formik@2.4.5(react@19.1.0))(fs@0.0.2)(history@4.10.1)(json-loader@0.5.7)(os-browserify@0.3.0)(react-dom@19.1.0(react@19.1.0))(react-error-overlay@6.0.9)(react-icons@4.12.0(react@19.1.0))(react-markdown@9.1.0(@types/react@19.1.0)(react@19.1.0))(react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-syntax-highlighter@15.6.1(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(stream-browserify@3.0.0)(tty-browserify@0.0.1)(url@0.11.4)(vm-browserify@1.1.2)(web-vitals@2.1.4)(with@7.0.2)(yup@0.32.11)
+        specifier: github:tomkat-cr/genericsuite-fe#develop
+        version: https://codeload.github.com/tomkat-cr/genericsuite-fe/tar.gz/491b1b86dd4cb456bcd53dbcefd994aa48405f14(axios@1.10.0)(buffer@5.7.1)(constants-browserify@1.0.0)(crypto-browserify@3.12.1)(downshift@8.5.0(react@19.1.0))(express-rate-limit@8.0.1(express@4.21.2))(express@4.21.2)(formik@2.4.5(react@19.1.0))(fs@0.0.2)(history@4.10.1)(json-loader@0.5.7)(os-browserify@0.3.0)(react-dom@19.1.0(react@19.1.0))(react-error-overlay@6.0.9)(react-icons@4.12.0(react@19.1.0))(react-markdown@9.1.0(@types/react@19.1.0)(react@19.1.0))(react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-syntax-highlighter@15.6.1(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(stream-browserify@3.0.0)(tty-browserify@0.0.1)(url@0.11.4)(vm-browserify@1.1.2)(web-vitals@2.1.4)(with@7.0.2)(yup@0.32.11)
       genericsuite-ai:
-        specifier: ^1.0.23
-        version: 1.0.23(3c6d9a11b9643e4b1df850ab66023713)
+        specifier: github:tomkat-cr/genericsuite-fe-ai#develop
+        version: https://codeload.github.com/tomkat-cr/genericsuite-fe-ai/tar.gz/192ee35d1664fa6609f45b0add3f7eb0d49b3e45(5dfa9ea7373377e5d56211a9507bd2fa)
     devDependencies:
       '@babel/cli':
         specifier: ^7.23.0
@@ -57,14 +57,14 @@ importers:
       '@babel/core':
         specifier: ^7.23.3
         version: 7.28.0
-      '@babel/plugin-proposal-class-properties':
-        specifier: ^7.18.6
-        version: 7.18.6(@babel/core@7.28.0)
       '@babel/plugin-proposal-private-property-in-object':
         specifier: 7.21.0-placeholder-for-preset-env.2
         version: 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.0)
       '@babel/plugin-syntax-jsx':
         specifier: ^7.23.3
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.28.0)
       '@babel/preset-env':
         specifier: ^7.23.3
@@ -91,8 +91,8 @@ importers:
         specifier: ^13.5.0
         version: 13.5.0(@testing-library/dom@9.3.4)
       '@vitejs/plugin-react':
-        specifier: ^4.6.0
-        version: 4.6.0(vite@5.4.19(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.43.1))
+        specifier: ^4.7.0
+        version: 4.7.0(vite@5.4.19(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.43.1))
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.21(postcss@8.5.6)
@@ -118,7 +118,7 @@ importers:
         specifier: ^0.12.7
         version: 0.12.7
       postcss:
-        specifier: ^8.4.31
+        specifier: ^8.5.6
         version: 8.5.6
       react-error-overlay:
         specifier: 6.0.9
@@ -365,13 +365,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  '@babel/plugin-proposal-class-properties@7.18.6':
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
@@ -1230,8 +1223,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@rolldown/pluginutils@1.0.0-beta.19':
-    resolution: {integrity: sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==}
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.44.1':
     resolution: {integrity: sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==}
@@ -1667,11 +1660,11 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@vitejs/plugin-react@4.6.0':
-    resolution: {integrity: sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==}
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vue/compiler-core@3.5.17':
     resolution: {integrity: sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==}
@@ -2767,6 +2760,12 @@ packages:
     resolution: {integrity: sha512-HXg6NvK35/cSYZCUKAtmlgCFyqKM4frEPbzrav5hRqb0GMz0E0lS5hfzYjSaiaE5ysnp/qI2aeZkeyeIAOeXzQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  express-rate-limit@8.0.1:
+    resolution: {integrity: sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.21.2:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
@@ -2943,15 +2942,16 @@ packages:
   generic-names@1.0.3:
     resolution: {integrity: sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==}
 
-  genericsuite-ai@1.0.23:
-    resolution: {integrity: sha512-JnesJXblHy1wwGN6gqSacEa08jFrv3LQSR9wvb1doSegkdZ1LePuS8QAtWTiJWtng7T+dTUBI0s3rmITQj7fug==}
+  genericsuite-ai@https://codeload.github.com/tomkat-cr/genericsuite-fe-ai/tar.gz/192ee35d1664fa6609f45b0add3f7eb0d49b3e45:
+    resolution: {tarball: https://codeload.github.com/tomkat-cr/genericsuite-fe-ai/tar.gz/192ee35d1664fa6609f45b0add3f7eb0d49b3e45}
+    version: 1.1.0
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      axios: ^1.6.8
+      axios: ^1.11.0
       browserify-zlib: ^0.2.0
       buffer: ^6.0.3
       constants-browserify: ^1.0.0
-      crypto-browserify: ^3.12.0
+      crypto-browserify: ^3.12.1
       downshift: ^8.2.3
       express: ^4.17.3
       formik: 2.4.5
@@ -2968,7 +2968,7 @@ packages:
       react-icons: ^4.12.0
       react-markdown: ^9.0.1
       react-router-dom: ^7.5.3
-      react-syntax-highlighter: ^15.5.0
+      react-syntax-highlighter: ^15.6.1
       rxjs: ^6.3.3
       stream-browserify: ^3.0.0
       stream-http: ^3.2.0
@@ -2984,16 +2984,18 @@ packages:
   genericsuite-be-scripts@1.0.14:
     resolution: {integrity: sha512-aX28+FmL/dHnMt2TUtBQqW+eOJlv55coZQEud8BRj081vk4+R0aGoQX//PsnuEisk5cAsue1PLD+ledJ8wZjnw==}
 
-  genericsuite@1.0.25:
-    resolution: {integrity: sha512-PTs7iwlf1i5pMJFxsgsicI1tOUKnsnrF0vWyINADPq4wJlmN5vRy6tznWo4yveJ18cgZh7gYCt28zusxMKepSg==}
+  genericsuite@https://codeload.github.com/tomkat-cr/genericsuite-fe/tar.gz/491b1b86dd4cb456bcd53dbcefd994aa48405f14:
+    resolution: {tarball: https://codeload.github.com/tomkat-cr/genericsuite-fe/tar.gz/491b1b86dd4cb456bcd53dbcefd994aa48405f14}
+    version: 1.1.0
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      axios: ^1.8.2
+      axios: ^1.11.0
       buffer: ^6.0.3
       constants-browserify: ^1.0.0
-      crypto-browserify: ^3.12.0
+      crypto-browserify: ^3.12.1
       downshift: ^8.2.3
       express: ^4.17.3
+      express-rate-limit: ^8.0.1
       formik: 2.4.5
       fs: ^0.0.2
       history: ^4.9.0
@@ -3293,6 +3295,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -5860,14 +5866,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.28.0)':
-    dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
@@ -6882,7 +6880,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.19': {}
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.44.1':
     optional: true
@@ -7350,12 +7348,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.6.0(vite@5.4.19(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.43.1))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.19(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.43.1))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
-      '@rolldown/pluginutils': 1.0.0-beta.19
+      '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 5.4.19(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.43.1)
@@ -8750,6 +8748,11 @@ snapshots:
       jest-mock: 30.0.2
       jest-util: 30.0.2
 
+  express-rate-limit@8.0.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
+      ip-address: 10.0.1
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -8980,7 +8983,7 @@ snapshots:
     dependencies:
       loader-utils: 0.2.17
 
-  genericsuite-ai@1.0.23(3c6d9a11b9643e4b1df850ab66023713):
+  genericsuite-ai@https://codeload.github.com/tomkat-cr/genericsuite-fe-ai/tar.gz/192ee35d1664fa6609f45b0add3f7eb0d49b3e45(5dfa9ea7373377e5d56211a9507bd2fa):
     dependencies:
       axios: 1.10.0
       browserify-zlib: 0.2.0
@@ -8991,7 +8994,7 @@ snapshots:
       express: 4.21.2
       formik: 2.4.5(react@19.1.0)
       fs: 0.0.2
-      genericsuite: 1.0.25(axios@1.10.0)(buffer@5.7.1)(constants-browserify@1.0.0)(crypto-browserify@3.12.1)(downshift@8.5.0(react@19.1.0))(express@4.21.2)(formik@2.4.5(react@19.1.0))(fs@0.0.2)(history@4.10.1)(json-loader@0.5.7)(os-browserify@0.3.0)(react-dom@19.1.0(react@19.1.0))(react-error-overlay@6.0.9)(react-icons@4.12.0(react@19.1.0))(react-markdown@9.1.0(@types/react@19.1.0)(react@19.1.0))(react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-syntax-highlighter@15.6.1(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(stream-browserify@3.0.0)(tty-browserify@0.0.1)(url@0.11.4)(vm-browserify@1.1.2)(web-vitals@2.1.4)(with@7.0.2)(yup@0.32.11)
+      genericsuite: https://codeload.github.com/tomkat-cr/genericsuite-fe/tar.gz/491b1b86dd4cb456bcd53dbcefd994aa48405f14(axios@1.10.0)(buffer@5.7.1)(constants-browserify@1.0.0)(crypto-browserify@3.12.1)(downshift@8.5.0(react@19.1.0))(express-rate-limit@8.0.1(express@4.21.2))(express@4.21.2)(formik@2.4.5(react@19.1.0))(fs@0.0.2)(history@4.10.1)(json-loader@0.5.7)(os-browserify@0.3.0)(react-dom@19.1.0(react@19.1.0))(react-error-overlay@6.0.9)(react-icons@4.12.0(react@19.1.0))(react-markdown@9.1.0(@types/react@19.1.0)(react@19.1.0))(react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-syntax-highlighter@15.6.1(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(stream-browserify@3.0.0)(tty-browserify@0.0.1)(url@0.11.4)(vm-browserify@1.1.2)(web-vitals@2.1.4)(with@7.0.2)(yup@0.32.11)
       history: 4.10.1
       https-browserify: 1.0.0
       json-loader: 0.5.7
@@ -9018,7 +9021,7 @@ snapshots:
 
   genericsuite-be-scripts@1.0.14: {}
 
-  genericsuite@1.0.25(axios@1.10.0)(buffer@5.7.1)(constants-browserify@1.0.0)(crypto-browserify@3.12.1)(downshift@8.5.0(react@19.1.0))(express@4.21.2)(formik@2.4.5(react@19.1.0))(fs@0.0.2)(history@4.10.1)(json-loader@0.5.7)(os-browserify@0.3.0)(react-dom@19.1.0(react@19.1.0))(react-error-overlay@6.0.9)(react-icons@4.12.0(react@19.1.0))(react-markdown@9.1.0(@types/react@19.1.0)(react@19.1.0))(react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-syntax-highlighter@15.6.1(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(stream-browserify@3.0.0)(tty-browserify@0.0.1)(url@0.11.4)(vm-browserify@1.1.2)(web-vitals@2.1.4)(with@7.0.2)(yup@0.32.11):
+  genericsuite@https://codeload.github.com/tomkat-cr/genericsuite-fe/tar.gz/491b1b86dd4cb456bcd53dbcefd994aa48405f14(axios@1.10.0)(buffer@5.7.1)(constants-browserify@1.0.0)(crypto-browserify@3.12.1)(downshift@8.5.0(react@19.1.0))(express-rate-limit@8.0.1(express@4.21.2))(express@4.21.2)(formik@2.4.5(react@19.1.0))(fs@0.0.2)(history@4.10.1)(json-loader@0.5.7)(os-browserify@0.3.0)(react-dom@19.1.0(react@19.1.0))(react-error-overlay@6.0.9)(react-icons@4.12.0(react@19.1.0))(react-markdown@9.1.0(@types/react@19.1.0)(react@19.1.0))(react-router-dom@7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-syntax-highlighter@15.6.1(react@19.1.0))(react@19.1.0)(rxjs@7.8.2)(stream-browserify@3.0.0)(tty-browserify@0.0.1)(url@0.11.4)(vm-browserify@1.1.2)(web-vitals@2.1.4)(with@7.0.2)(yup@0.32.11):
     dependencies:
       axios: 1.10.0
       buffer: 5.7.1
@@ -9026,6 +9029,7 @@ snapshots:
       crypto-browserify: 3.12.1
       downshift: 8.5.0(react@19.1.0)
       express: 4.21.2
+      express-rate-limit: 8.0.1(express@4.21.2)
       formik: 2.4.5(react@19.1.0)
       fs: 0.0.2
       history: 4.10.1
@@ -9413,6 +9417,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip-address@10.0.1: {}
 
   ip-address@9.0.5:
     dependencies:

--- a/docs/Sample-Code/exampleapp/pnpm-workspace.yaml
+++ b/docs/Sample-Code/exampleapp/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages:
-  - "apps/*"
-  - "packages/*"
+  - apps/*
+  - packages/*
+
+onlyBuiltDependencies:
+  - '@tailwindcss/oxide'
+  - core-js-pure
+  - esbuild


### PR DESCRIPTION
Add: new `update-pnpm` command in ExampleApp Makefile for streamlined installation.
Change: Update CHANGELOG format to include parentheses for version dates.
Change: update pnpm-lock.yaml to reference GitHub repositories for `genericsuite` and `genericsuite-ai`, and update dependencies.
Change: Enhance pnpm-workspace.yaml to specify built dependencies for better package management.