### PR TITLE
Fix build_if_required.sh install and build all apps if any of them does not have node_modules directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Removed
 
 
+## [1.3.2] - 2025-11-19
+
+### Added
+- New "lsof" command to Makefile for listing open TCP ports.
+
+### Changed
+- Update "build_if_required.sh" to use "make install" instead of npm commands.
+- Enhance "clean_directory.sh" to also find and remove ".log" files for removal.
+- Update ExampleApp "README.md" file to add MCP Server section and improve documentation.
+
+### Fixed
+- Fix the "build_if_required.sh" script failure to install and build all ExampleApp apps if any of them does not have node_modules directory.
+
+
 ## [1.3.1] - 2025-11-19
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,6 @@ exampleapp-clean:
 	@echo "Press Enter to continue to clean all directories (node_modules, dist, etc.)"
 	@read
 	bash docs/Sample-Code/exampleapp/scripts/clean_directory.sh ./docs/Sample-Code/exampleapp false true
+
+lsof:
+	sudo lsof -PiTCP -sTCP:LISTEN

--- a/docs/Sample-Code/exampleapp/README.md
+++ b/docs/Sample-Code/exampleapp/README.md
@@ -2,7 +2,7 @@
 
 ![ExampleApp Banner](./assets/exampleapp_banner_01.png)
 
-**ExampleApp** is a full-stack example application demonstrating a modern web app architecture with multiple backend services and a React-based frontend implementing GenericSuite.
+**ExampleApp** is a full-stack example application demonstrating a modern web app architecture with multiple Python-based backend services and a React-based frontend implementing GenericSuite.
 
 It is inspired by the principles of Caloric Deficit. The purpose is to achieve weight loss goals and maintain a better lifestyle, based on proper nutrition. 
 
@@ -18,34 +18,43 @@ The application is structured as a monorepo using [TurboRepo](https://turborepo.
 
 ## 🚀 Features
 
-- **Frontend**: Modern React application with Vite
+### Frontend
 
-- **Backend Options**:
+- A Modern React application with Vite.
 
-  - FastAPI (Python)
-  - Flask (Python)
-  - Chalice (Python)
-  - MCP Server (Python)
+### Backend Options
 
-- **Database Options**:
+- FastAPI (Python)
+- Flask (Python)
+- Chalice (Python)
+- MCP Server (Python)
 
-  - DynamoDB (AWS)
-  - MongoDB (MongoDB Atlas or self-hosted)
+### MCP Server
 
-- **Development Tools**:
+- A Model Context Protocol (MCP) server for nutrition management.
 
-  - pnpm for package management
-  - TurboRepo for monorepo management
-  - Environment-based configuration
+### Database Options
+
+- DynamoDB (AWS)
+- MongoDB (MongoDB Atlas or self-hosted)
+
+### Development Tools
+
+- Environment-based configuration
+- TurboRepo for monorepo management
+- Vite, Webpack, and Create React App for frontend development
+- uv, pipenv, or poetry for Python dependency management
+- pnpm for Node.js package management
 
 ## 🛠️ Prerequisites
 
 ### Software
+
 - [Git](https://www.atlassian.com/git/tutorials/install-git)
-- Node version 20+, installed via [NVM (Node Package Manager)](https://nodejs.org/en/download/package-manager) or [NPM and Node](https://nodejs.org/en/download) install (version specified in `.nvmrc`).
+- [Node.js](https://nodejs.org/en/download/package-manager) version 20+, installed via [NVM (Node Package Manager)](https://nodejs.org/en/download/package-manager) or [NPM and Node](https://nodejs.org/en/download) install (version specified in `.nvmrc`).
 - [pnpm](https://pnpm.io/installation) (version 10.12.4 or compatible)
-- Make: [Mac](https://formulae.brew.sh/formula/make) | [Windows](https://stackoverflow.com/questions/32127524/how-to-install-and-use-make-in-windows)
-- Python version >= 3.10 and < 4.0 (version specified in `.python-version` files and installable with [pyenv](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation) preferably)
+- [Make](https://formulae.brew.sh/formula/make): [Mac](https://formulae.brew.sh/formula/make) | [Windows](https://stackoverflow.com/questions/32127524/how-to-install-and-use-make-in-windows)
+- [Python](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation) preferably) version >= 3.10 and < 4.0 (version specified in `.python-version` files and installable with [pyenv](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation) preferably)
 - [uv](https://docs.astral.sh/uv/getting-started/installation/), [pipenv](https://pipenv.pypa.io/en/latest/), or [poetry](https://python-poetry.org/docs/) (for Python dependency management)
 
 ### Services
@@ -79,10 +88,7 @@ cd genericsuite-basecamp
 
 2. Install dependencies:
 
-```bash
-# Install pnpm if not already installed
-npm install -g pnpm
-```
+Install git, pnpm, make, python, and other dependencies as specified in the [Prerequisites](#-prerequisites) section.
 
 ### Configuration
 
@@ -115,22 +121,22 @@ BACKEND_LOCAL_PORT=5001
 # BACKEND_LOCAL_PORT=5021
 ```
 
-**Note:** Once changed the `BACKEND_LOCAL_PORT` variable, press Ctrl-C to stop the development servers and run `make exampleapp-run` again.
+**Note:** If `BACKEND_LOCAL_PORT` variable is changed, press Ctrl-C to stop the development servers and run `make exampleapp-run` again.
 
-4. Use **https**: by default the application will use http (non-secure), if you want to use https:
+4. Use **https**: by default the application will use `http` (non-secure), if you want to use `https`:
     - Set the `RUN_PROTOCOL` variable to `https` in the `apps/ui/.env`, `apps/api-fastapi/.env`, `apps/api-flask/.env`, `apps/api-chalice/.env` files.
-    - Generate a self-signed certificate and keys (only once):
 
+    - Generate a self-signed certificate and keys (only once) using the following command:
 ```bash
 make exampleapp-create-ssl-certs
 ```
     
-**Note:** Once changed the `RUN_PROTOCOL` variable, press Ctrl-C to stop the development servers and run `make exampleapp-run` again.
+**Note:** If `RUN_PROTOCOL` variable is changed, press Ctrl-C to stop the development servers and run `make exampleapp-run` again.
 
 5. Use "webpack": by default the application will use "vite", if you want to use "webpack":
     - Uncomment the line `RUN_METHOD="webpack"` in the `apps/ui/.env`.
     
-**Note:** Once changed the `RUN_METHOD` variable, press Ctrl-C to stop the development servers and run `make exampleapp-run` again.
+**Note:** If `RUN_METHOD` variable is changed, press Ctrl-C to stop the development servers and run `make exampleapp-run` again.
 
 ## 🏃‍♂️ Running the Application
 
@@ -140,6 +146,18 @@ Start the development servers:
 
 ```bash
 make exampleapp-run
+```
+
+Install all dependencies:
+
+```bash
+make exampleapp-install-all
+```
+
+Update all dependencies:
+
+```bash
+make exampleapp-update-all
 ```
 
 ### Start a new GenericSuite project
@@ -210,6 +228,7 @@ exampleapp/
 │   ├── api-fastapi/      # FastAPI backend API
 │   ├── api-flask/        # Flask backend API
 │   ├── config_dbdef/     # Database configuration
+│   ├── mcp-server/       # MCP Server
 │   └── ui/               # React frontend application
 ├── packages/             # Shared packages
 ├── scripts/              # Utility scripts

--- a/docs/Sample-Code/exampleapp/scripts/build_if_required.sh
+++ b/docs/Sample-Code/exampleapp/scripts/build_if_required.sh
@@ -16,12 +16,21 @@ DIRS_TO_PROCESS=(
     "./apps/api-flask"
 )
 echo "DIRS_TO_PROCESS: ${DIRS_TO_PROCESS[@]}"
+RUN_INSTALL="false"
 for dir in "${DIRS_TO_PROCESS[@]}"; do
     if [ ! -d "$SCRIPT_DIR/../$dir/node_modules" ]; then
+        RUN_INSTALL="true"
+        break
+    fi
+done
+echo "RUN_INSTALL: $RUN_INSTALL"
+if [ "$RUN_INSTALL" = "true" ]; then
+    for dir in "${DIRS_TO_PROCESS[@]}"; do
         echo ""
         echo "Building $dir..."
         echo "--------"
-        cd "$SCRIPT_DIR/../$dir" && npm install && npm run build && cd -
+        # cd "$SCRIPT_DIR/../$dir" && npm install && npm run build && cd -
+        cd "$SCRIPT_DIR/../$dir" && make install && cd -
         echo ""
-    fi
-done
+    done
+fi

--- a/docs/Sample-Code/exampleapp/scripts/clean_directory.sh
+++ b/docs/Sample-Code/exampleapp/scripts/clean_directory.sh
@@ -52,7 +52,7 @@ clean_directory() {
         if [ "${remove_envs}" = "true" ]; then
             echo ""
             echo ".env files to remove:"
-            find "${directory_path_to_clean}" -type f \( -name ".env" -o -name "*.bak" \) -exec bash -c 'show_file "$0"' {} \;
+            find "${directory_path_to_clean}" -type f \( -name ".env" -o -name "*.bak" -o -name "*.log" \) -exec bash -c 'show_file "$0"' {} \;
         fi
         echo ""
         echo "Press [Enter] key to confirm the directories/files to remove [FTP-010]"
@@ -67,7 +67,7 @@ clean_directory() {
     if [ "${remove_envs}" = "true" ]; then
         echo ""
         echo "Removing .env files..."
-        find "${directory_path_to_clean}" -type f \( -name ".env" -o -name "*.bak" \) -exec bash -c 'remove_item "$0"' {} \;
+        find "${directory_path_to_clean}" -type f \( -name ".env" -o -name "*.bak" -o -name "*.log" \) -exec bash -c 'remove_item "$0"' {} \;
     fi
     if [ "${debug}" = "true" ]; then
         echo ""

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@
 
 Generic Suite (GS) is the ultimate development library designed to streamline both frontend and backend workflows, enabling rapid app development with AI-powered enhancements. Whether you're building robust APIs, scalable databases, or dynamic user interfaces, GS provides the flexibility and efficiency needed to accelerate your projects.
 
-[Release Notes](./Releases/index.md)
+[Release Notes](./Releases/index.md) | [ExampleApp](./Sample-Code/exampleapp/README.md)
 
 ## Why Choose Generic Suite?
 


### PR DESCRIPTION
Fix: build_if_required.sh install and build all apps if any of them does not have node_modules directory.
Change: Update build_if_required.sh to use 'make install' instead of npm commands.
Change: Enhance clean_directory.sh to also find and remove .log files for removal.
Change: Update ExampleApp "README.md" file to add MCP Server section and improve documentation.
Add: New lsof command to Makefile for listing open TCP ports.
GS-230